### PR TITLE
Fixed notification in iOS not poping up if NotifyTime is not set.

### DIFF
--- a/scr/Plugin.LocalNotification/Platform/iOS/LocalNotificationService.cs
+++ b/scr/Plugin.LocalNotification/Platform/iOS/LocalNotificationService.cs
@@ -156,15 +156,7 @@ namespace Plugin.LocalNotification.Platform.iOS
 
         private NSDateComponents GetNSDateComponentsFromDateTime(DateTime? nullableDateTime)
         {
-            if (!nullableDateTime.HasValue)
-            {
-                return new NSDateComponents
-                {
-                    Second = 1
-                };
-            }
-
-            var dateTime = nullableDateTime.Value;
+            var dateTime = nullableDateTime ?? DateTime.Now.AddSeconds(1);
 
             return new NSDateComponents
             {


### PR DESCRIPTION
Previously, if NotifyTime property is not set before calling Show method, the notification will only work correctly for the first time. Now the notification will pop up every time when notification is receive.