### PR TITLE
[iOS]Remove icon badges after tap on notification

### DIFF
--- a/scr/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/scr/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using UIKit;
 using UserNotifications;
 using Xamarin.Forms;
 
@@ -31,7 +32,9 @@ namespace Plugin.LocalNotification.Platform.iOS
                 {
                     Data = dictionary[LocalNotificationService.ExtraReturnData].ToString()
                 };
+                var appBadges = UIApplication.SharedApplication.ApplicationIconBadgeNumber - Convert.ToInt32(response.Notification.Request.Content.Badge.ToString());
                 MessagingCenter.Send(subscribeItem, typeof(LocalNotificationTappedEvent).FullName);
+                UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### What does this PR do?
Fix issue #11 

##### Why are we doing this? Any context or related work?
Clear badge after click local notification