### PR TITLE
Remove badges in iOS10+ if user clear notification in notification panel

### DIFF
--- a/Sample/Direct/LocalNotification.Sample.iOS/AppDelegate.cs
+++ b/Sample/Direct/LocalNotification.Sample.iOS/AppDelegate.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Linq;
 using Foundation;
 using Plugin.LocalNotification.Platform.iOS;
 using UIKit;
+using UserNotifications;
+using Xamarin.Forms;
 
 namespace LocalNotification.Sample.iOS
 {
@@ -37,6 +40,22 @@ namespace LocalNotification.Sample.iOS
             {
                 LocalNotificationService.NotifyNotificationTapped(notification);
             }
+        }
+
+        public override void WillEnterForeground(UIApplication uiApplication)
+        {
+            //Remove badges on app enter foreground if user cleared the notification in the notification panel 
+            UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationList) => {
+                if (notificationList.Any())
+                {
+                    return;
+                }
+                var appBadges = 0;
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
+                });
+            });
         }
     }
 }

--- a/Sample/Direct/LocalNotification.Sample.iOS/AppDelegate.cs
+++ b/Sample/Direct/LocalNotification.Sample.iOS/AppDelegate.cs
@@ -32,7 +32,7 @@ namespace LocalNotification.Sample.iOS
             return base.FinishedLaunching(app, options);
         }
 
-		// This method only requires for iOS 8 , 9
+        // This method only requires for iOS 8 , 9
         public override void ReceivedLocalNotification(UIApplication application, UILocalNotification notification)
         {
             //Change UIApplicationState to suit different situations
@@ -44,18 +44,27 @@ namespace LocalNotification.Sample.iOS
 
         public override void WillEnterForeground(UIApplication uiApplication)
         {
-            //Remove badges on app enter foreground if user cleared the notification in the notification panel 
-            UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationList) => {
-                if (notificationList.Any())
+            if (UIDevice.CurrentDevice.CheckSystemVersion(10, 0))
+            {
+                //Remove badges on app enter foreground if user cleared the notification in the notification panel 
+                UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationList) =>
                 {
-                    return;
-                }
-                var appBadges = 0;
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
+                    if (notificationList.Any())
+                    {
+                        return;
+                    }
+
+                    var appBadges = 0;
+                    Device.BeginInvokeOnMainThread(() =>
+                    {
+                        UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
+                    });
                 });
-            });
+            }
+            else
+            {
+                base.WillEnterForeground(uiApplication);
+            }
         }
     }
 }

--- a/Sample/NuGet/Sample.iOS/AppDelegate.cs
+++ b/Sample/NuGet/Sample.iOS/AppDelegate.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using Foundation;
 using Plugin.LocalNotification.Platform.iOS;
 using UIKit;
+using UserNotifications;
+using Xamarin.Forms;
 
 namespace LocalNotification.Sample.iOS
 {
@@ -40,6 +42,22 @@ namespace LocalNotification.Sample.iOS
             {
                 LocalNotificationService.NotifyNotificationTapped(notification);
             }
+        }
+        
+        public override void WillEnterForeground(UIApplication uiApplication)
+        {
+            //Remove badges on app enter foreground if user cleared the notification in the notification panel 
+            UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationList) => {
+                if (notificationList.Any())
+                {
+                    return;
+                }
+                var appBadges = 0;
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
+                });
+            });
         }
     }
 }

--- a/Sample/NuGet/Sample.iOS/AppDelegate.cs
+++ b/Sample/NuGet/Sample.iOS/AppDelegate.cs
@@ -46,18 +46,27 @@ namespace LocalNotification.Sample.iOS
         
         public override void WillEnterForeground(UIApplication uiApplication)
         {
-            //Remove badges on app enter foreground if user cleared the notification in the notification panel 
-            UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationList) => {
-                if (notificationList.Any())
+            if (UIDevice.CurrentDevice.CheckSystemVersion(10, 0))
+            {
+                //Remove badges on app enter foreground if user cleared the notification in the notification panel 
+                UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationList) =>
                 {
-                    return;
-                }
-                var appBadges = 0;
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
+                    if (notificationList.Any())
+                    {
+                        return;
+                    }
+
+                    var appBadges = 0;
+                    Device.BeginInvokeOnMainThread(() =>
+                    {
+                        UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
+                    });
                 });
-            });
+            }
+            else
+            {
+                base.WillEnterForeground(uiApplication);
+            }
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?
Remove badges in iOS10+ if user clear notification in notification panel

##### Why are we doing this? Any context or related work?
Remove badges in iOS10+ if user clear notification in notification panel